### PR TITLE
Fix isCraftingModule

### DIFF
--- a/src/main/java/com/tom/logisticsbridge/pipe/CraftingManager.java
+++ b/src/main/java/com/tom/logisticsbridge/pipe/CraftingManager.java
@@ -195,7 +195,7 @@ public class CraftingManager extends PipeLogisticsChassi implements IIdPipe {
 		return false;
 	}
 	public static boolean isCraftingModule(ItemStack itemStack){
-		return itemStack.getItem() == LPItems.modules.get(ModuleCrafter.class);
+		return itemStack.getItem() == Item.REGISTRY.getObject(LPItems.modules.get(ModuleCrafter.getName()));
 	}
 	public boolean isUpgradeModule(ItemStack itemStack, int slot){
 		return ChassiGuiProvider.checkStack(itemStack, this, slot);


### PR DESCRIPTION
`LPItems.modules` dont hold direct Item instances anymore. This is to be more flexible and compatible with changes to recipes/items.